### PR TITLE
Fixed: Set up Application Default Credentials -- Error

### DIFF
--- a/pkg/database/firestore.go
+++ b/pkg/database/firestore.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/firestore"
+	"google.golang.org/api/option"
 )
 
 // FirestoreDB is a struct that holds the firestore client
@@ -24,10 +25,13 @@ func NewFirestore(projectID, databaseID string) *FirestoreDB {
 
 // Connect creates a new firestore client and assigns it to the FirestoreDB struct
 func (db *FirestoreDB) Connect(ctx context.Context) error {
+	opt := option.WithCredentialsFile("serviceAccountKey.json")
+
 	client, err := firestore.NewClientWithDatabase(
 		ctx,
 		db.ProjectID,
 		db.DatabaseID,
+		opt,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create firestore client: %w", err)


### PR DESCRIPTION
This Error: Failed to connect to Firestore: failed to create firestore client: credentials: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information